### PR TITLE
fix(module) Fix module name "svelte"

### DIFF
--- a/types/svelte/svelte.d.ts
+++ b/types/svelte/svelte.d.ts
@@ -21,5 +21,5 @@ declare module "svelte" {
 
   export function tick(): Promise<void>;
 
-  export function createEventDispatcher<D>(): (type: string, detail: D) => void;
+  export function createEventDispatcher<D>(): (type: string, detail?: D) => void;
 }


### PR DESCRIPTION
See: https://svelte.dev/examples#modal (in Model.svelte file)