### PR TITLE
Add null to target type to be compatible with document.getElementById

### DIFF
--- a/types/svelte/svelte.d.ts
+++ b/types/svelte/svelte.d.ts
@@ -1,6 +1,6 @@
 declare module "*.svelte" {
   interface ComponentOptions {
-    target: HTMLElement;
+    target: HTMLElement | null;
     anchor?: HTMLElement | null;
     props?: {};
     hydrate?: boolean;


### PR DESCRIPTION
Ensures compatibility with document.getElementById and document.querySelector
From `lib.dom.d.ts`
`getElementById(elementId: string): Element | null;`
`querySelector<E extends Element = Element>(selectors: string): E | null;`